### PR TITLE
feat(nightshift): dark mode engine core

### DIFF
--- a/apps/nightshift/src/background/index.ts
+++ b/apps/nightshift/src/background/index.ts
@@ -1,7 +1,90 @@
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  if (msg.action === 'GET_STATE') {
-    sendResponse({ ok: true });
-    return true;
+interface FilterOptions {
+  brightness?: number;
+  contrast?: number;
+  sepia?: number;
+}
+
+interface GlobalState {
+  globalEnabled: boolean;
+  filterOptions: FilterOptions;
+}
+
+const DEFAULT_STATE: GlobalState = {
+  globalEnabled: false,
+  filterOptions: {},
+};
+
+let cachedState: GlobalState = { ...DEFAULT_STATE };
+
+// Load state from storage on startup
+chrome.storage.local.get('nightshift_state', (result) => {
+  if (result.nightshift_state) {
+    cachedState = result.nightshift_state as GlobalState;
   }
-  return false;
+});
+
+function saveState(): void {
+  chrome.storage.local.set({ nightshift_state: cachedState });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  switch (msg.action) {
+    case 'GET_STATE':
+      sendResponse(cachedState);
+      return true;
+
+    case 'SET_ENABLED': {
+      cachedState.globalEnabled = msg.enabled;
+      saveState();
+
+      // Notify all tabs
+      chrome.tabs.query({}, (tabs) => {
+        for (const tab of tabs) {
+          if (tab.id === undefined) continue;
+          chrome.tabs.sendMessage(
+            tab.id,
+            {
+              action: msg.enabled ? 'APPLY_DARK' : 'REMOVE_DARK',
+              options: cachedState.filterOptions,
+            },
+            () => {
+              // Ignore errors for tabs without content script
+              if (chrome.runtime.lastError) {
+                // expected for chrome:// and edge cases
+              }
+            },
+          );
+        }
+      });
+      sendResponse({ ok: true });
+      return true;
+    }
+
+    case 'SET_FILTER_OPTIONS': {
+      cachedState.filterOptions = { ...cachedState.filterOptions, ...msg.options };
+      saveState();
+
+      // Notify sender tab only
+      if (sender.tab?.id !== undefined) {
+        chrome.tabs.sendMessage(sender.tab.id, {
+          action: 'UPDATE_FILTER',
+          options: cachedState.filterOptions,
+        });
+      }
+      sendResponse({ ok: true });
+      return true;
+    }
+
+    case 'ALREADY_DARK_DETECTED':
+      // Content script reports page is already dark — no action needed
+      sendResponse({ ok: true });
+      return true;
+
+    case 'DARK_STATE_CHANGED':
+      sendResponse({ ok: true });
+      return true;
+
+    default:
+      return false;
+  }
 });

--- a/apps/nightshift/src/content/dark-engine.ts
+++ b/apps/nightshift/src/content/dark-engine.ts
@@ -1,0 +1,156 @@
+const STYLE_ID = 'nightshift-filter';
+const COUNTER_INVERT_SELECTOR = 'img, video, canvas, svg, picture, object, embed';
+const COUNTER_INVERT_ATTR = 'data-nightshift-ci';
+const THROTTLE_MS = 100;
+
+interface FilterOptions {
+  brightness?: number;
+  contrast?: number;
+  sepia?: number;
+}
+
+interface EngineState {
+  enabled: boolean;
+  options: FilterOptions;
+}
+
+let observer: MutationObserver | null = null;
+let throttleTimeout: ReturnType<typeof setTimeout> | null = null;
+const state: EngineState = { enabled: false, options: {} };
+
+function buildFilterValue(opts: FilterOptions): string {
+  const parts = ['invert(1)', 'hue-rotate(180deg)'];
+  if (opts.brightness !== undefined && opts.brightness !== 100) {
+    parts.push(`brightness(${opts.brightness}%)`);
+  }
+  if (opts.contrast !== undefined && opts.contrast !== 100) {
+    parts.push(`contrast(${opts.contrast}%)`);
+  }
+  if (opts.sepia !== undefined && opts.sepia !== 0) {
+    parts.push(`sepia(${opts.sepia}%)`);
+  }
+  return parts.join(' ');
+}
+
+function buildStyleContent(opts: FilterOptions): string {
+  const filterValue = buildFilterValue(opts);
+  return [
+    `html { filter: ${filterValue} !important; }`,
+    `${COUNTER_INVERT_SELECTOR} { filter: invert(1) hue-rotate(180deg) !important; }`,
+    'iframe { filter: none !important; }',
+  ].join('\n');
+}
+
+function counterInvertNew(): void {
+  const elements = document.querySelectorAll(COUNTER_INVERT_SELECTOR);
+  for (const el of elements) {
+    if (!el.hasAttribute(COUNTER_INVERT_ATTR)) {
+      el.setAttribute(COUNTER_INVERT_ATTR, '1');
+    }
+  }
+}
+
+function startObserver(): void {
+  if (observer) return;
+
+  observer = new MutationObserver(() => {
+    if (throttleTimeout) return;
+    throttleTimeout = setTimeout(() => {
+      throttleTimeout = null;
+      requestAnimationFrame(() => {
+        counterInvertNew();
+      });
+    }, THROTTLE_MS);
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['src'],
+  });
+}
+
+function stopObserver(): void {
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+  if (throttleTimeout) {
+    clearTimeout(throttleTimeout);
+    throttleTimeout = null;
+  }
+}
+
+export function applyDarkMode(opts?: FilterOptions): void {
+  if (state.enabled) return;
+
+  state.enabled = true;
+  state.options = opts ?? {};
+
+  let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement('style');
+    style.id = STYLE_ID;
+    document.documentElement.appendChild(style);
+  }
+  style.textContent = buildStyleContent(state.options);
+
+  counterInvertNew();
+  startObserver();
+}
+
+export function removeDarkMode(): void {
+  state.enabled = false;
+  state.options = {};
+
+  const style = document.getElementById(STYLE_ID);
+  if (style) {
+    style.remove();
+  }
+
+  const marked = document.querySelectorAll(`[${COUNTER_INVERT_ATTR}]`);
+  for (const el of marked) {
+    el.removeAttribute(COUNTER_INVERT_ATTR);
+  }
+
+  stopObserver();
+}
+
+export function updateFilter(opts: FilterOptions): void {
+  state.options = { ...state.options, ...opts };
+
+  const style = document.getElementById(STYLE_ID);
+  if (style) {
+    style.textContent = buildStyleContent(state.options);
+  }
+}
+
+function getLuminance(rgb: string): number {
+  const match = rgb.match(/\d+/g);
+  if (!match) return 1;
+  const [r, g, b] = match.map(Number).map((c) => c / 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function isAlreadyDark(): boolean {
+  const body = document.body;
+  if (!body) return false;
+
+  const bg = getComputedStyle(body).backgroundColor;
+  return getLuminance(bg) < 0.15;
+}
+
+const BUNDLED_OVERRIDES: Record<string, string> = {};
+
+export function hasOverride(domain: string): boolean {
+  return domain in BUNDLED_OVERRIDES;
+}
+
+export function loadOverride(domain: string): string | null {
+  return BUNDLED_OVERRIDES[domain] ?? null;
+}
+
+export function getState(): EngineState {
+  return { ...state };
+}

--- a/apps/nightshift/src/content/index.ts
+++ b/apps/nightshift/src/content/index.ts
@@ -1,3 +1,11 @@
+import {
+  applyDarkMode,
+  getState,
+  isAlreadyDark,
+  removeDarkMode,
+  updateFilter,
+} from './dark-engine';
+
 (() => {
   if ((window as unknown as Record<string, unknown>).__nightshiftInjected) {
     try {
@@ -9,11 +17,54 @@
   }
   (window as unknown as Record<string, unknown>).__nightshiftInjected = true;
 
-  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-    if (msg.action === 'PING') {
-      sendResponse({ ok: true });
-      return true;
+  // FOUC Phase 1: apply filter immediately at document_start if cached state says ON
+  chrome.runtime.sendMessage({ action: 'GET_STATE' }, (response) => {
+    if (chrome.runtime.lastError) return;
+    if (response?.globalEnabled) {
+      applyDarkMode(response.filterOptions);
     }
-    return false;
+  });
+
+  // FOUC Phase 2: check if page is already dark after DOM loads
+  const onReady = () => {
+    if (getState().enabled && isAlreadyDark()) {
+      removeDarkMode();
+      chrome.runtime.sendMessage({
+        action: 'ALREADY_DARK_DETECTED',
+        luminance: 0,
+      });
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady, { once: true });
+  } else {
+    onReady();
+  }
+
+  // Message handler
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    switch (msg.action) {
+      case 'APPLY_DARK':
+        applyDarkMode(msg.options);
+        sendResponse({ ok: true });
+        return true;
+      case 'REMOVE_DARK':
+        removeDarkMode();
+        sendResponse({ ok: true });
+        return true;
+      case 'UPDATE_FILTER':
+        updateFilter(msg.options);
+        sendResponse({ ok: true });
+        return true;
+      case 'GET_STATE':
+        sendResponse(getState());
+        return true;
+      case 'IS_ALREADY_DARK':
+        sendResponse({ dark: isAlreadyDark() });
+        return true;
+      default:
+        return false;
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- Create `dark-engine.ts` — core dark mode module with CSS filter injection
- Counter-inversion for media elements (img, video, canvas, svg, picture, object, embed)
- Cross-origin iframes get `filter: none` (original appearance, not color-negative)
- MutationObserver with 100ms `setTimeout` throttle + `requestAnimationFrame` for DOM writes
- `isAlreadyDark()` luminance-based stub (body backgroundColor < 0.15)
- `hasOverride()`/`loadOverride()` domain override API (empty registry, ready for S5)
- `updateFilter()` for brightness/contrast/sepia adjustment without DOM re-scan
- Background service worker with `chrome.storage.local` state persistence + message routing
- FOUC Phase 1/2 in content script: apply at `document_start`, refine at `DOMContentLoaded`

## Test plan
- [x] `pnpm type-check --filter=@rayshar/nightshift` passes
- [x] `pnpm lint --filter=@rayshar/nightshift` passes
- [x] `pnpm build --filter=@rayshar/nightshift` — content.js 2.56KB (engine bundled), background.js 0.93KB
- [ ] Load extension → visit bright page → send `APPLY_DARK` from devtools → page inverts
- [ ] Images/videos remain correctly colored (counter-inverted)
- [ ] Send `REMOVE_DARK` → page reverts to original

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)