### PR TITLE
feat(nightshift): toggle UI walking skeleton

### DIFF
--- a/apps/nightshift/src/popup/App.tsx
+++ b/apps/nightshift/src/popup/App.tsx
@@ -1,16 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function App() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage({ action: 'GET_STATE' }, (response) => {
+      if (chrome.runtime.lastError) {
+        setLoading(false);
+        return;
+      }
+      setEnabled(response?.globalEnabled ?? false);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    const newEnabled = !enabled;
+    setEnabled(newEnabled);
+    chrome.runtime.sendMessage({ action: 'SET_ENABLED', enabled: newEnabled });
+  }, [enabled]);
+
   return (
-    <div className="w-80 p-4">
+    <div className="w-64 p-3">
       <Card>
-        <CardHeader>
-          <CardTitle>NightShift</CardTitle>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">NightShift</CardTitle>
         </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <Button variant="default" className="w-full">
-            Toggle Dark Mode
+        <CardContent>
+          <Button
+            variant={enabled ? 'secondary' : 'default'}
+            className="w-full"
+            onClick={handleToggle}
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : enabled ? 'Dark Mode ON' : 'Dark Mode OFF'}
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Implement dark mode toggle button in popup with loading/enabled/disabled states
- Sync state with background service worker via `GET_STATE` and `SET_ENABLED` messages
- Walking skeleton: popup → background → content script pipeline now functional end-to-end

Closes #6

## Verification
- `pnpm type-check` ✅
- `pnpm lint` ✅ (12 files, 0 issues)
- `pnpm build` ✅ (popup 227KB, background 0.9KB, content 2.5KB)

## Test plan
- [ ] Load extension in Chrome, click popup — toggle button visible
- [ ] Click toggle — sends SET_ENABLED to background, broadcasts to all tabs
- [ ] Reload popup — state persisted via GET_STATE from background

🤖 Generated with [Claude Code](https://claude.com/claude-code)