### PR TITLE
feat(nightshift): per-site settings & domain memory

### DIFF
--- a/apps/nightshift/src/background/index.ts
+++ b/apps/nightshift/src/background/index.ts
@@ -4,22 +4,39 @@ interface FilterOptions {
   sepia?: number;
 }
 
+interface PerSiteSettings {
+  enabled: boolean | 'auto';
+  brightness: number;
+  contrast: number;
+  sepia: number;
+}
+
+const DEFAULT_PER_SITE: PerSiteSettings = {
+  enabled: 'auto',
+  brightness: 100,
+  contrast: 100,
+  sepia: 0,
+};
+
 interface GlobalState {
   globalEnabled: boolean;
   filterOptions: FilterOptions;
+  perSite: Record<string, PerSiteSettings>;
 }
 
 const DEFAULT_STATE: GlobalState = {
   globalEnabled: false,
   filterOptions: {},
+  perSite: {},
 };
 
-let cachedState: GlobalState = { ...DEFAULT_STATE };
+let cachedState: GlobalState = { ...DEFAULT_STATE, perSite: {} };
 
 // Load state from storage on startup
 chrome.storage.local.get('nightshift_state', (result) => {
   if (result.nightshift_state) {
-    cachedState = result.nightshift_state as GlobalState;
+    const loaded = result.nightshift_state as GlobalState;
+    cachedState = { ...DEFAULT_STATE, ...loaded, perSite: loaded.perSite ?? {} };
   }
 });
 
@@ -27,33 +44,103 @@ function saveState(): void {
   chrome.storage.local.set({ nightshift_state: cachedState });
 }
 
+function getEffectiveEnabled(domain: string): boolean {
+  const siteConfig = cachedState.perSite[domain];
+  if (siteConfig && siteConfig.enabled !== 'auto') {
+    return siteConfig.enabled;
+  }
+  return cachedState.globalEnabled;
+}
+
+function getEffectiveFilterOptions(domain: string): FilterOptions {
+  const siteConfig = cachedState.perSite[domain];
+  if (siteConfig) {
+    const opts: FilterOptions = { ...cachedState.filterOptions };
+    if (siteConfig.brightness !== 100) opts.brightness = siteConfig.brightness;
+    if (siteConfig.contrast !== 100) opts.contrast = siteConfig.contrast;
+    if (siteConfig.sepia !== 0) opts.sepia = siteConfig.sepia;
+    return opts;
+  }
+  return cachedState.filterOptions;
+}
+
+function notifyTab(tabId: number, domain: string): void {
+  const enabled = getEffectiveEnabled(domain);
+  chrome.tabs.sendMessage(
+    tabId,
+    {
+      action: enabled ? 'APPLY_DARK' : 'REMOVE_DARK',
+      options: getEffectiveFilterOptions(domain),
+    },
+    () => {
+      if (chrome.runtime.lastError) {
+        // expected for chrome:// and edge cases
+      }
+    },
+  );
+}
+
+function getDomainFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
-    case 'GET_STATE':
-      sendResponse(cachedState);
+    case 'GET_STATE': {
+      const domain = msg.domain ?? getDomainFromUrl(sender.tab?.url ?? sender.url);
+      const effectiveEnabled = domain ? getEffectiveEnabled(domain) : cachedState.globalEnabled;
+      const siteConfig = domain ? (cachedState.perSite[domain] ?? null) : null;
+      sendResponse({
+        ...cachedState,
+        effectiveEnabled,
+        siteConfig,
+        domain,
+      });
       return true;
+    }
 
     case 'SET_ENABLED': {
       cachedState.globalEnabled = msg.enabled;
       saveState();
 
-      // Notify all tabs
+      // Notify all tabs — each gets its effective state based on per-site overrides
       chrome.tabs.query({}, (tabs) => {
         for (const tab of tabs) {
           if (tab.id === undefined) continue;
-          chrome.tabs.sendMessage(
-            tab.id,
-            {
-              action: msg.enabled ? 'APPLY_DARK' : 'REMOVE_DARK',
-              options: cachedState.filterOptions,
-            },
-            () => {
-              // Ignore errors for tabs without content script
-              if (chrome.runtime.lastError) {
-                // expected for chrome:// and edge cases
-              }
-            },
-          );
+          const domain = getDomainFromUrl(tab.url);
+          if (!domain) continue;
+          notifyTab(tab.id, domain);
+        }
+      });
+      sendResponse({ ok: true });
+      return true;
+    }
+
+    case 'SET_SITE_ENABLED': {
+      const { domain, enabled } = msg as { domain: string; enabled: boolean | 'auto' };
+      if (enabled === 'auto') {
+        delete cachedState.perSite[domain];
+      } else {
+        cachedState.perSite[domain] = {
+          ...(cachedState.perSite[domain] ?? DEFAULT_PER_SITE),
+          enabled,
+        };
+      }
+      saveState();
+
+      // Notify tabs on this domain
+      chrome.tabs.query({}, (tabs) => {
+        for (const tab of tabs) {
+          if (tab.id === undefined) continue;
+          const tabDomain = getDomainFromUrl(tab.url);
+          if (tabDomain === domain) {
+            notifyTab(tab.id, domain);
+          }
         }
       });
       sendResponse({ ok: true });
@@ -76,7 +163,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     }
 
     case 'ALREADY_DARK_DETECTED':
-      // Content script reports page is already dark — no action needed
       sendResponse({ ok: true });
       return true;
 

--- a/apps/nightshift/src/content/index.ts
+++ b/apps/nightshift/src/content/index.ts
@@ -17,10 +17,13 @@ import {
   }
   (window as unknown as Record<string, unknown>).__nightshiftInjected = true;
 
-  // FOUC Phase 1: apply filter immediately at document_start if cached state says ON
-  chrome.runtime.sendMessage({ action: 'GET_STATE' }, (response) => {
+  const currentDomain = window.location.hostname;
+
+  // FOUC Phase 1: apply filter immediately at document_start
+  // Background returns effectiveEnabled (per-site override > global)
+  chrome.runtime.sendMessage({ action: 'GET_STATE', domain: currentDomain }, (response) => {
     if (chrome.runtime.lastError) return;
-    if (response?.globalEnabled) {
+    if (response?.effectiveEnabled) {
       applyDarkMode(response.filterOptions);
     }
   });
@@ -41,6 +44,30 @@ import {
   } else {
     onReady();
   }
+
+  // Cross-tab sync: listen for storage changes directly (0 hop, < 500ms)
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local' || !changes.nightshift_state) return;
+
+    const newState = changes.nightshift_state.newValue;
+    if (!newState) return;
+
+    const siteConfig = newState.perSite?.[currentDomain];
+    let shouldBeEnabled: boolean;
+
+    if (siteConfig && siteConfig.enabled !== 'auto') {
+      shouldBeEnabled = siteConfig.enabled;
+    } else {
+      shouldBeEnabled = newState.globalEnabled;
+    }
+
+    const engineState = getState();
+    if (shouldBeEnabled && !engineState.enabled) {
+      applyDarkMode(newState.filterOptions);
+    } else if (!shouldBeEnabled && engineState.enabled) {
+      removeDarkMode();
+    }
+  });
 
   // Message handler
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/apps/nightshift/src/popup/App.tsx
+++ b/apps/nightshift/src/popup/App.tsx
@@ -3,26 +3,67 @@ import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
+type SiteMode = boolean | 'auto';
+
 export function App() {
-  const [enabled, setEnabled] = useState(false);
+  const [globalEnabled, setGlobalEnabled] = useState(false);
+  const [siteMode, setSiteMode] = useState<SiteMode>('auto');
+  const [domain, setDomain] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    chrome.runtime.sendMessage({ action: 'GET_STATE' }, (response) => {
-      if (chrome.runtime.lastError) {
-        setLoading(false);
-        return;
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0];
+      let tabDomain: string | null = null;
+      if (tab?.url) {
+        try {
+          tabDomain = new URL(tab.url).hostname;
+        } catch {
+          // chrome:// or other special URLs
+        }
       }
-      setEnabled(response?.globalEnabled ?? false);
-      setLoading(false);
+      setDomain(tabDomain);
+
+      chrome.runtime.sendMessage({ action: 'GET_STATE', domain: tabDomain }, (response) => {
+        if (chrome.runtime.lastError) {
+          setLoading(false);
+          return;
+        }
+        setGlobalEnabled(response?.globalEnabled ?? false);
+        if (response?.siteConfig) {
+          setSiteMode(response.siteConfig.enabled ?? 'auto');
+        } else {
+          setSiteMode('auto');
+        }
+        setLoading(false);
+      });
     });
   }, []);
 
-  const handleToggle = useCallback(() => {
-    const newEnabled = !enabled;
-    setEnabled(newEnabled);
+  const handleGlobalToggle = useCallback(() => {
+    const newEnabled = !globalEnabled;
+    setGlobalEnabled(newEnabled);
     chrome.runtime.sendMessage({ action: 'SET_ENABLED', enabled: newEnabled });
-  }, [enabled]);
+  }, [globalEnabled]);
+
+  const handleSiteToggle = useCallback(() => {
+    if (!domain) return;
+    // Cycle: auto → ON → OFF → auto
+    let next: SiteMode;
+    if (siteMode === 'auto') {
+      next = true;
+    } else if (siteMode === true) {
+      next = false;
+    } else {
+      next = 'auto';
+    }
+    setSiteMode(next);
+    chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: next });
+  }, [domain, siteMode]);
+
+  const effectiveEnabled = siteMode !== 'auto' ? siteMode : globalEnabled;
+
+  const siteLabel = siteMode === 'auto' ? 'Auto (global)' : siteMode ? 'Always ON' : 'Always OFF';
 
   return (
     <div className="w-64 p-3">
@@ -30,15 +71,32 @@ export function App() {
         <CardHeader className="pb-2">
           <CardTitle className="text-base">NightShift</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="flex flex-col gap-2">
           <Button
-            variant={enabled ? 'secondary' : 'default'}
+            variant={globalEnabled ? 'secondary' : 'default'}
             className="w-full"
-            onClick={handleToggle}
+            onClick={handleGlobalToggle}
             disabled={loading}
           >
-            {loading ? 'Loading...' : enabled ? 'Dark Mode ON' : 'Dark Mode OFF'}
+            {loading ? 'Loading...' : globalEnabled ? 'Global: ON' : 'Global: OFF'}
           </Button>
+
+          {domain && (
+            <>
+              <div className="text-xs text-muted-foreground truncate" title={domain}>
+                {domain}
+              </div>
+              <Button
+                variant={effectiveEnabled ? 'secondary' : 'outline'}
+                size="sm"
+                className="w-full"
+                onClick={handleSiteToggle}
+                disabled={loading}
+              >
+                {siteLabel}
+              </Button>
+            </>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Per-domain dark mode configuration — each hostname gets independent ON/OFF/Auto setting
- Cross-tab sync via `chrome.storage.onChanged` (0-hop, <500ms latency)
- Per-site overrides global toggle (precedence: per-site > global)
- Popup shows current domain name + tri-state per-site toggle (Auto/ON/OFF)

Closes #7

## Changes

### Background (`src/background/index.ts`)
- Extended `GlobalState` with `perSite: Record<string, PerSiteSettings>`
- Added `getEffectiveEnabled(domain)` — computes per-site > global precedence
- Added `SET_SITE_ENABLED` message handler (set/clear per-site override)
- `GET_STATE` now returns `effectiveEnabled`, `siteConfig`, `domain`
- `SET_ENABLED` broadcasts per-domain effective state (not just global)

### Content Script (`src/content/index.ts`)
- FOUC Phase 1 sends `domain` in `GET_STATE` for per-site aware response
- Added `chrome.storage.onChanged` listener for cross-tab sync
- Sync computes effective state locally (per-site > global)

### Popup (`src/popup/App.tsx`)
- Extracts current domain via `chrome.tabs.query`
- Shows domain name below global toggle
- Tri-state per-site button: Auto (global) → Always ON → Always OFF → cycle

## Verification
- `pnpm type-check` ✅
- `pnpm lint` ✅ (12 files, 0 issues)
- `pnpm build` ✅ (popup 228KB, background 1.9KB, content 2.9KB)

## Test plan
- [ ] Enable global → verify applies to all sites
- [ ] Set github.com to "Always ON" → disable global → github.com stays dark
- [ ] Set wikipedia.org to "Always OFF" → enable global → wikipedia.org stays light
- [ ] Open 2 tabs on same domain → change per-site in one → other syncs <500ms
- [ ] Set per-site back to "Auto" → follows global toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)