### PR TITLE
feat(nightshift): tiered dark mode detection

### DIFF
--- a/apps/nightshift/src/background/index.ts
+++ b/apps/nightshift/src/background/index.ts
@@ -18,6 +18,15 @@ const DEFAULT_PER_SITE: PerSiteSettings = {
   sepia: 0,
 };
 
+interface DarkDetection {
+  isDark: boolean;
+  confidence: 'high' | 'low' | 'none';
+  signals: string[];
+}
+
+// Transient per-tab detection state (not persisted to storage)
+const tabDetections: Record<number, DarkDetection> = {};
+
 interface GlobalState {
   globalEnabled: boolean;
   filterOptions: FilterOptions;
@@ -89,17 +98,38 @@ function getDomainFromUrl(url: string | undefined): string | null {
   }
 }
 
+// Clean up detection state when tabs are closed or navigated
+chrome.tabs.onRemoved.addListener((tabId) => {
+  delete tabDetections[tabId];
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'loading') {
+    delete tabDetections[tabId];
+  }
+});
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
     case 'GET_STATE': {
       const domain = msg.domain ?? getDomainFromUrl(sender.tab?.url ?? sender.url);
       const effectiveEnabled = domain ? getEffectiveEnabled(domain) : cachedState.globalEnabled;
       const siteConfig = domain ? (cachedState.perSite[domain] ?? null) : null;
+
+      // Look up detection for active tab (popup passes tabId via msg)
+      let darkDetection: DarkDetection | null = null;
+      if (msg.tabId !== undefined) {
+        darkDetection = tabDetections[msg.tabId] ?? null;
+      } else if (sender.tab?.id !== undefined) {
+        darkDetection = tabDetections[sender.tab.id] ?? null;
+      }
+
       sendResponse({
         ...cachedState,
         effectiveEnabled,
         siteConfig,
         domain,
+        darkDetection,
       });
       return true;
     }
@@ -162,9 +192,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return true;
     }
 
-    case 'ALREADY_DARK_DETECTED':
+    case 'ALREADY_DARK_DETECTED': {
+      const tabId = sender.tab?.id;
+      if (tabId !== undefined && msg.detection) {
+        tabDetections[tabId] = msg.detection;
+      }
       sendResponse({ ok: true });
       return true;
+    }
 
     case 'DARK_STATE_CHANGED':
       sendResponse({ ok: true });

--- a/apps/nightshift/src/content/dark-engine.ts
+++ b/apps/nightshift/src/content/dark-engine.ts
@@ -133,12 +133,69 @@ function getLuminance(rgb: string): number {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-export function isAlreadyDark(): boolean {
-  const body = document.body;
-  if (!body) return false;
+export interface DetectionResult {
+  isDark: boolean;
+  confidence: 'high' | 'low' | 'none';
+  signals: string[];
+}
 
-  const bg = getComputedStyle(body).backgroundColor;
-  return getLuminance(bg) < 0.15;
+export function detectNativeDarkMode(): DetectionResult {
+  const signals: string[] = [];
+
+  // High confidence: <meta name="color-scheme" content="dark">
+  const meta = document.querySelector('meta[name="color-scheme"]');
+  if (meta?.getAttribute('content')?.includes('dark')) {
+    signals.push('meta-color-scheme');
+    return { isDark: true, confidence: 'high', signals };
+  }
+
+  // High confidence: body background luminance < 0.15
+  const body = document.body;
+  if (body) {
+    const bg = getComputedStyle(body).backgroundColor;
+    if (getLuminance(bg) < 0.15) {
+      signals.push('luminance');
+      return { isDark: true, confidence: 'high', signals };
+    }
+  }
+
+  // Low confidence: class-based detection on <html> and <body>
+  const root = document.documentElement;
+  const darkClasses = ['dark', 'theme-dark', 'dark-mode'];
+  for (const el of [root, body]) {
+    if (!el) continue;
+    for (const cls of darkClasses) {
+      if (el.classList.contains(cls)) {
+        signals.push(`class:${cls}`);
+      }
+    }
+  }
+
+  // Low confidence: data attribute detection
+  const darkAttrs: Array<[string, string]> = [
+    ['data-theme', 'dark'],
+    ['data-color-mode', 'dark'],
+    ['data-bs-theme', 'dark'],
+  ];
+  for (const el of [root, body]) {
+    if (!el) continue;
+    for (const [attr, value] of darkAttrs) {
+      if (el.getAttribute(attr) === value) {
+        signals.push(`attr:${attr}`);
+      }
+    }
+  }
+
+  if (signals.length > 0) {
+    return { isDark: true, confidence: 'low', signals };
+  }
+
+  return { isDark: false, confidence: 'none', signals: [] };
+}
+
+export function isAlreadyDark(): boolean {
+  const result = detectNativeDarkMode();
+  return result.isDark && result.confidence === 'high';
 }
 
 const BUNDLED_OVERRIDES: Record<string, string> = {};

--- a/apps/nightshift/src/content/index.ts
+++ b/apps/nightshift/src/content/index.ts
@@ -1,7 +1,8 @@
 import {
+  type DetectionResult,
   applyDarkMode,
+  detectNativeDarkMode,
   getState,
-  isAlreadyDark,
   removeDarkMode,
   updateFilter,
 } from './dark-engine';
@@ -28,15 +29,22 @@ import {
     }
   });
 
-  // FOUC Phase 2: check if page is already dark after DOM loads
+  // FOUC Phase 2: detect native dark mode after DOM loads
   const onReady = () => {
-    if (getState().enabled && isAlreadyDark()) {
+    const detection: DetectionResult = detectNativeDarkMode();
+
+    if (!detection.isDark) return;
+
+    if (detection.confidence === 'high' && getState().enabled) {
+      // High confidence: auto-skip — remove filter immediately
       removeDarkMode();
-      chrome.runtime.sendMessage({
-        action: 'ALREADY_DARK_DETECTED',
-        luminance: 0,
-      });
     }
+
+    // Report detection to background (both high and low)
+    chrome.runtime.sendMessage({
+      action: 'ALREADY_DARK_DETECTED',
+      detection,
+    });
   };
 
   if (document.readyState === 'loading') {
@@ -88,7 +96,7 @@ import {
         sendResponse(getState());
         return true;
       case 'IS_ALREADY_DARK':
-        sendResponse({ dark: isAlreadyDark() });
+        sendResponse({ detection: detectNativeDarkMode() });
         return true;
       default:
         return false;

--- a/apps/nightshift/src/popup/App.tsx
+++ b/apps/nightshift/src/popup/App.tsx
@@ -5,10 +5,17 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 type SiteMode = boolean | 'auto';
 
+interface DarkDetection {
+  isDark: boolean;
+  confidence: 'high' | 'low' | 'none';
+  signals: string[];
+}
+
 export function App() {
   const [globalEnabled, setGlobalEnabled] = useState(false);
   const [siteMode, setSiteMode] = useState<SiteMode>('auto');
   const [domain, setDomain] = useState<string | null>(null);
+  const [darkDetection, setDarkDetection] = useState<DarkDetection | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -24,19 +31,25 @@ export function App() {
       }
       setDomain(tabDomain);
 
-      chrome.runtime.sendMessage({ action: 'GET_STATE', domain: tabDomain }, (response) => {
-        if (chrome.runtime.lastError) {
+      chrome.runtime.sendMessage(
+        { action: 'GET_STATE', domain: tabDomain, tabId: tab?.id },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            setLoading(false);
+            return;
+          }
+          setGlobalEnabled(response?.globalEnabled ?? false);
+          if (response?.siteConfig) {
+            setSiteMode(response.siteConfig.enabled ?? 'auto');
+          } else {
+            setSiteMode('auto');
+          }
+          if (response?.darkDetection) {
+            setDarkDetection(response.darkDetection);
+          }
           setLoading(false);
-          return;
-        }
-        setGlobalEnabled(response?.globalEnabled ?? false);
-        if (response?.siteConfig) {
-          setSiteMode(response.siteConfig.enabled ?? 'auto');
-        } else {
-          setSiteMode('auto');
-        }
-        setLoading(false);
-      });
+        },
+      );
     });
   }, []);
 
@@ -61,9 +74,18 @@ export function App() {
     chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: next });
   }, [domain, siteMode]);
 
+  const handleApplyAnyway = useCallback(() => {
+    if (!domain) return;
+    setSiteMode(true);
+    chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: true });
+  }, [domain]);
+
   const effectiveEnabled = siteMode !== 'auto' ? siteMode : globalEnabled;
 
   const siteLabel = siteMode === 'auto' ? 'Auto (global)' : siteMode ? 'Always ON' : 'Always OFF';
+
+  // Show detection indicator when dark mode detected AND user hasn't overridden
+  const showDetection = darkDetection?.isDark && siteMode === 'auto';
 
   return (
     <div className="w-64 p-3">
@@ -95,6 +117,23 @@ export function App() {
               >
                 {siteLabel}
               </Button>
+
+              {showDetection && (
+                <div className="rounded-md border border-yellow-600/30 bg-yellow-950/20 p-2">
+                  <p className="text-xs text-yellow-400">Natywny dark mode wykryty</p>
+                  {darkDetection.confidence === 'high' && (
+                    <p className="text-xs text-muted-foreground mt-0.5">Auto-skip aktywny</p>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full mt-1.5"
+                    onClick={handleApplyAnyway}
+                  >
+                    Apply anyway
+                  </Button>
+                </div>
+              )}
             </>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary

- Add `detectNativeDarkMode()` returning `DetectionResult` with confidence levels (high/low/none) and signal list
- High-confidence signals (`<meta name="color-scheme" content="dark">`, body luminance < 0.15) auto-skip dark mode
- Low-confidence signals (`class="dark"`, `data-theme="dark"`, `data-bs-theme="dark"`) show popup indicator only
- Popup shows "Natywny dark mode wykryty" banner with "Apply anyway" button
- "Apply anyway" persists override via per-site settings (from #7)
- Per-tab transient detection state in background (cleaned up on tab close/navigate)

Closes #8

## Test plan

- [ ] Visit github.com (has `<meta name="color-scheme" content="dark">`) → NightShift auto-skips
- [ ] Open popup on github.com → shows "Natywny dark mode wykryty" + "Auto-skip aktywny"
- [ ] Click "Apply anyway" → dark mode applied, per-site set to "Always ON"
- [ ] Visit page with only `class="dark"` on html → popup shows indicator (NOT auto-skip)
- [ ] Visit regular bright site → no detection, dark mode applied normally
- [ ] Visit `chrome://` page → no errors (graceful no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)