### PR TITLE
feat(nightshift): site-specific CSS overrides

### DIFF
--- a/apps/nightshift/src/content/dark-engine.ts
+++ b/apps/nightshift/src/content/dark-engine.ts
@@ -1,4 +1,7 @@
+import { hasOverride as checkOverride, getOverrideCSS } from './overrides';
+
 const STYLE_ID = 'nightshift-filter';
+const OVERRIDE_STYLE_ID = 'nightshift-override';
 const COUNTER_INVERT_SELECTOR = 'img, video, canvas, svg, picture, object, embed';
 const COUNTER_INVERT_ATTR = 'data-nightshift-ci';
 const THROTTLE_MS = 100;
@@ -109,6 +112,11 @@ export function removeDarkMode(): void {
     style.remove();
   }
 
+  const overrideStyle = document.getElementById(OVERRIDE_STYLE_ID);
+  if (overrideStyle) {
+    overrideStyle.remove();
+  }
+
   const marked = document.querySelectorAll(`[${COUNTER_INVERT_ATTR}]`);
   for (const el of marked) {
     el.removeAttribute(COUNTER_INVERT_ATTR);
@@ -198,14 +206,36 @@ export function isAlreadyDark(): boolean {
   return result.isDark && result.confidence === 'high';
 }
 
-const BUNDLED_OVERRIDES: Record<string, string> = {};
-
 export function hasOverride(domain: string): boolean {
-  return domain in BUNDLED_OVERRIDES;
+  return checkOverride(domain);
 }
 
 export function loadOverride(domain: string): string | null {
-  return BUNDLED_OVERRIDES[domain] ?? null;
+  return getOverrideCSS(domain);
+}
+
+export function applyOverride(domain: string): boolean {
+  const css = getOverrideCSS(domain);
+  if (!css) return false;
+
+  state.enabled = true;
+
+  // Remove generic filter if present
+  const filterStyle = document.getElementById(STYLE_ID);
+  if (filterStyle) {
+    filterStyle.remove();
+  }
+
+  // Apply dedicated CSS override
+  let overrideStyle = document.getElementById(OVERRIDE_STYLE_ID) as HTMLStyleElement | null;
+  if (!overrideStyle) {
+    overrideStyle = document.createElement('style');
+    overrideStyle.id = OVERRIDE_STYLE_ID;
+    document.documentElement.appendChild(overrideStyle);
+  }
+  overrideStyle.textContent = css;
+
+  return true;
 }
 
 export function getState(): EngineState {

--- a/apps/nightshift/src/content/index.ts
+++ b/apps/nightshift/src/content/index.ts
@@ -1,8 +1,10 @@
 import {
   type DetectionResult,
   applyDarkMode,
+  applyOverride,
   detectNativeDarkMode,
   getState,
+  hasOverride,
   removeDarkMode,
   updateFilter,
 } from './dark-engine';
@@ -20,12 +22,16 @@ import {
 
   const currentDomain = window.location.hostname;
 
-  // FOUC Phase 1: apply filter immediately at document_start
-  // Background returns effectiveEnabled (per-site override > global)
+  // FOUC Phase 1: apply dark mode immediately at document_start
+  // Check for site-specific CSS override first, then fall back to generic filter
   chrome.runtime.sendMessage({ action: 'GET_STATE', domain: currentDomain }, (response) => {
     if (chrome.runtime.lastError) return;
     if (response?.effectiveEnabled) {
-      applyDarkMode(response.filterOptions);
+      if (hasOverride(currentDomain)) {
+        applyOverride(currentDomain);
+      } else {
+        applyDarkMode(response.filterOptions);
+      }
     }
   });
 

--- a/apps/nightshift/src/content/overrides/github.css
+++ b/apps/nightshift/src/content/overrides/github.css
@@ -1,0 +1,98 @@
+/* NightShift Override: GitHub (github.com)
+ * Targets stable selectors: data attributes, CSS custom properties, semantic HTML
+ * Avoids class-name selectors where possible
+ */
+
+/* Force dark color scheme */
+[data-color-mode] {
+  color-scheme: dark;
+}
+
+/* Base page colors */
+html,
+body {
+  background-color: #0d1117 !important;
+  color: #e6edf3 !important;
+}
+
+/* Navigation and headers */
+[data-color-mode] header,
+[data-color-mode] nav {
+  background-color: #161b22 !important;
+  color: #e6edf3 !important;
+}
+
+/* Main content area */
+[data-color-mode] main {
+  background-color: #0d1117 !important;
+}
+
+/* Repository file list, issues, PR list */
+[role="grid"],
+[role="table"] {
+  background-color: #0d1117 !important;
+}
+
+[role="row"] {
+  border-color: #30363d !important;
+}
+
+/* Markdown content */
+.markdown-body {
+  background-color: transparent !important;
+  color: #e6edf3 !important;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3 {
+  border-color: #30363d !important;
+}
+
+/* Code blocks — preserve syntax highlighting */
+.markdown-body pre {
+  background-color: #161b22 !important;
+  border: 1px solid #30363d !important;
+}
+
+.markdown-body code {
+  background-color: rgba(110, 118, 129, 0.2) !important;
+}
+
+/* Links */
+a {
+  color: #58a6ff !important;
+}
+
+/* Buttons — use GitHub's own tokens where possible */
+[data-color-mode] button,
+[data-color-mode] [role="button"] {
+  border-color: #30363d !important;
+}
+
+/* Sidebar */
+[data-color-mode] aside {
+  background-color: #0d1117 !important;
+}
+
+/* Input fields */
+[data-color-mode] input,
+[data-color-mode] textarea,
+[data-color-mode] select {
+  background-color: #0d1117 !important;
+  color: #e6edf3 !important;
+  border-color: #30363d !important;
+}
+
+/* Cards and containers */
+[data-color-mode] [role="dialog"],
+[data-color-mode] details {
+  background-color: #161b22 !important;
+  border-color: #30363d !important;
+}
+
+/* Footer */
+[data-color-mode] footer {
+  background-color: #0d1117 !important;
+  border-color: #30363d !important;
+}

--- a/apps/nightshift/src/content/overrides/hackernews.css
+++ b/apps/nightshift/src/content/overrides/hackernews.css
@@ -1,0 +1,91 @@
+/* NightShift Override: Hacker News (news.ycombinator.com)
+ * Ultra-stable DOM — pure semantic HTML with table-based layout
+ * Selectors: element types and [bgcolor] attributes (stable since 2007)
+ */
+
+/* Base */
+html,
+body {
+  background-color: #1a1a1a !important;
+  color: #d4d4d4 !important;
+}
+
+/* Top bar — HN uses bgcolor attribute */
+[bgcolor="#ff6600"],
+[bgcolor="ff6600"] {
+  background-color: #ff6600 !important;
+}
+
+/* Main content table */
+table {
+  background-color: #1a1a1a !important;
+}
+
+td {
+  color: #d4d4d4 !important;
+}
+
+/* Story titles */
+td .titleline a {
+  color: #8ab4f8 !important;
+}
+
+td .titleline a:visited {
+  color: #9b8ec8 !important;
+}
+
+/* Subtext (points, author, time) */
+td .subtext {
+  color: #888 !important;
+}
+
+td .subtext a {
+  color: #888 !important;
+}
+
+/* Comment text */
+td .commtext {
+  color: #d4d4d4 !important;
+}
+
+/* Comment links */
+td .commtext a {
+  color: #8ab4f8 !important;
+}
+
+/* Rank numbers */
+td .rank {
+  color: #888 !important;
+}
+
+/* Site domain after title */
+td .sitestr {
+  color: #888 !important;
+}
+
+/* Input fields (login, submit) */
+input,
+textarea {
+  background-color: #2d2d2d !important;
+  color: #d4d4d4 !important;
+  border: 1px solid #444 !important;
+}
+
+/* Links general */
+a {
+  color: #8ab4f8 !important;
+}
+
+a:visited {
+  color: #9b8ec8 !important;
+}
+
+/* Toggle triangles and navigation */
+[class="togg"] {
+  color: #888 !important;
+}
+
+/* Footer */
+td [color="#ff6600"] {
+  color: #ff6600 !important;
+}

--- a/apps/nightshift/src/content/overrides/index.ts
+++ b/apps/nightshift/src/content/overrides/index.ts
@@ -1,0 +1,17 @@
+import githubCSS from './github.css?raw';
+import hackernewsCSS from './hackernews.css?raw';
+import redditCSS from './reddit.css?raw';
+
+const overrides: Record<string, string> = {
+  'github.com': githubCSS,
+  'www.reddit.com': redditCSS,
+  'news.ycombinator.com': hackernewsCSS,
+};
+
+export function hasOverride(domain: string): boolean {
+  return domain in overrides;
+}
+
+export function getOverrideCSS(domain: string): string | null {
+  return overrides[domain] ?? null;
+}

--- a/apps/nightshift/src/content/overrides/reddit.css
+++ b/apps/nightshift/src/content/overrides/reddit.css
@@ -1,0 +1,87 @@
+/* NightShift Override: Reddit (www.reddit.com)
+ * Targets CSS custom properties and semantic selectors
+ * Reddit uses --color-* custom properties extensively
+ */
+
+/* Force dark scheme via Reddit's own CSS custom properties */
+:root {
+  --color-neutral-background: #1a1a1b !important;
+  --color-neutral-background-hover: #2a2a2b !important;
+  --color-neutral-background-selected: #3a3a3b !important;
+  --color-neutral-content: #d7dadc !important;
+  --color-neutral-content-weak: #818384 !important;
+  --color-neutral-border-medium: #343536 !important;
+  --color-neutral-border-weak: #474748 !important;
+  --color-tone-1: #d7dadc !important;
+  --color-tone-2: #818384 !important;
+  --color-tone-7: #1a1a1b !important;
+}
+
+/* Base */
+html,
+body {
+  background-color: #030303 !important;
+  color: #d7dadc !important;
+}
+
+/* Header / nav bar */
+header,
+nav {
+  background-color: #1a1a1b !important;
+  border-color: #343536 !important;
+}
+
+/* Post cards */
+[data-testid="post-container"],
+article {
+  background-color: #1a1a1b !important;
+  border-color: #343536 !important;
+  color: #d7dadc !important;
+}
+
+/* Sidebar */
+aside {
+  background-color: #1a1a1b !important;
+  border-color: #343536 !important;
+}
+
+/* Comments */
+[data-testid="comment"] {
+  border-color: #343536 !important;
+}
+
+/* Links */
+a {
+  color: #4fbcff !important;
+}
+
+a:visited {
+  color: #9b8ec8 !important;
+}
+
+/* Input fields */
+input,
+textarea,
+select {
+  background-color: #272729 !important;
+  color: #d7dadc !important;
+  border-color: #343536 !important;
+}
+
+/* Buttons */
+button {
+  border-color: #343536 !important;
+}
+
+/* Modals and overlays */
+[role="dialog"] {
+  background-color: #1a1a1b !important;
+  border-color: #343536 !important;
+}
+
+/* Dropdown menus */
+[role="menu"],
+[role="listbox"] {
+  background-color: #1a1a1b !important;
+  border-color: #343536 !important;
+}


### PR DESCRIPTION
## Summary
- Add dedicated CSS dark themes for GitHub, Reddit, and Hacker News
- Override architecture: domain → CSS mapping with Vite `?raw` imports
- Content script checks for site override before applying generic filter
- Stable selectors: data attributes, CSS custom properties, element types

Closes #9

## Test plan
- [ ] Load github.com — custom dark theme instead of inverted colors
- [ ] Load reddit.com — custom dark theme with proper variables
- [ ] Load news.ycombinator.com — custom dark theme with proper colors
- [ ] Load any other site — generic invert filter still works
- [ ] Toggle off/on — override removed/reapplied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)