### PR TITLE
feat(nightshift): freemium CTA banner

### DIFF
--- a/apps/nightshift/src/popup/App.tsx
+++ b/apps/nightshift/src/popup/App.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
+import { CTABanner } from './cta-banner';
 
 type SiteMode = boolean | 'auto';
 
@@ -244,8 +245,8 @@ export function App() {
             </div>
           )}
 
-          {/* CTA reserved space (S6 fills this) */}
-          <div className="min-h-8" />
+          {/* Freemium CTA */}
+          <CTABanner />
         </CardContent>
       </Card>
     </div>

--- a/apps/nightshift/src/popup/cta-banner.tsx
+++ b/apps/nightshift/src/popup/cta-banner.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const LANDING_URL = 'https://nightshift.rayshar.com/pro';
+const DISMISS_KEY = 'ctaDismissed';
+
+export function CTABanner() {
+  const [dismissed, setDismissed] = useState(true); // hidden until loaded
+
+  useEffect(() => {
+    chrome.storage.session.get(DISMISS_KEY, (result) => {
+      setDismissed(!!result[DISMISS_KEY]);
+    });
+  }, []);
+
+  const handleDismiss = () => {
+    chrome.storage.session.set({ [DISMISS_KEY]: true });
+    setDismissed(true);
+  };
+
+  const handleClick = () => {
+    chrome.tabs.create({ url: LANDING_URL });
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md bg-gradient-to-r from-purple-600 to-blue-600 px-3 py-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        className="text-xs font-medium text-white hover:underline"
+      >
+        Upgrade to NightShift Pro
+      </button>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="text-white/60 hover:text-white text-sm leading-none"
+        aria-label="Dismiss"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dismissable CTA banner at bottom of popup
- Uses `chrome.storage.session` for dismiss state (auto-cleared on browser close)
- Opens landing page in new tab on click
- Zero external network requests — pure local HTML/CSS

Closes #11

## Test plan
- [ ] Open popup — CTA banner visible at bottom
- [ ] Click CTA — landing page opens in new tab
- [ ] Click X dismiss — banner hidden
- [ ] Reopen popup — banner stays hidden (same session)
- [ ] Restart browser — banner visible again

🤖 Generated with [Claude Code](https://claude.com/claude-code)