### PR TITLE
refactor(nightshift): simplify — shared types, fix bugs, optimize

### DIFF
--- a/apps/nightshift/src/background/index.ts
+++ b/apps/nightshift/src/background/index.ts
@@ -1,8 +1,5 @@
-interface FilterOptions {
-  brightness?: number;
-  contrast?: number;
-  sepia?: number;
-}
+import { MSG } from '../shared/messages';
+import type { DarkDetection, FilterOptions } from '../shared/types';
 
 interface PerSiteSettings {
   enabled: boolean | 'auto';
@@ -17,12 +14,6 @@ const DEFAULT_PER_SITE: PerSiteSettings = {
   contrast: 100,
   sepia: 0,
 };
-
-interface DarkDetection {
-  isDark: boolean;
-  confidence: 'high' | 'low' | 'none';
-  signals: string[];
-}
 
 // Transient per-tab detection state (not persisted to storage)
 const tabDetections: Record<number, DarkDetection> = {};
@@ -78,7 +69,7 @@ function notifyTab(tabId: number, domain: string): void {
   chrome.tabs.sendMessage(
     tabId,
     {
-      action: enabled ? 'APPLY_DARK' : 'REMOVE_DARK',
+      action: enabled ? MSG.APPLY_DARK : MSG.REMOVE_DARK,
       options: getEffectiveFilterOptions(domain),
     },
     () => {
@@ -98,6 +89,17 @@ function getDomainFromUrl(url: string | undefined): string | null {
   }
 }
 
+function notifyAllTabs(): void {
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      if (tab.id === undefined) continue;
+      const domain = getDomainFromUrl(tab.url);
+      if (!domain) continue;
+      notifyTab(tab.id, domain);
+    }
+  });
+}
+
 // Clean up detection state when tabs are closed or navigated
 chrome.tabs.onRemoved.addListener((tabId) => {
   delete tabDetections[tabId];
@@ -111,7 +113,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
-    case 'GET_STATE': {
+    case MSG.GET_STATE: {
       const domain = msg.domain ?? getDomainFromUrl(sender.tab?.url ?? sender.url);
       const effectiveEnabled = domain ? getEffectiveEnabled(domain) : cachedState.globalEnabled;
       const siteConfig = domain ? (cachedState.perSite[domain] ?? null) : null;
@@ -125,7 +127,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       }
 
       sendResponse({
-        ...cachedState,
+        globalEnabled: cachedState.globalEnabled,
+        filterOptions: cachedState.filterOptions,
         effectiveEnabled,
         siteConfig,
         domain,
@@ -134,24 +137,15 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return true;
     }
 
-    case 'SET_ENABLED': {
+    case MSG.SET_ENABLED: {
       cachedState.globalEnabled = msg.enabled;
       saveState();
-
-      // Notify all tabs — each gets its effective state based on per-site overrides
-      chrome.tabs.query({}, (tabs) => {
-        for (const tab of tabs) {
-          if (tab.id === undefined) continue;
-          const domain = getDomainFromUrl(tab.url);
-          if (!domain) continue;
-          notifyTab(tab.id, domain);
-        }
-      });
+      notifyAllTabs();
       sendResponse({ ok: true });
       return true;
     }
 
-    case 'SET_SITE_ENABLED': {
+    case MSG.SET_SITE_ENABLED: {
       const { domain, enabled } = msg as { domain: string; enabled: boolean | 'auto' };
       if (enabled === 'auto') {
         delete cachedState.perSite[domain];
@@ -177,22 +171,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return true;
     }
 
-    case 'SET_FILTER_OPTIONS': {
+    case MSG.SET_FILTER_OPTIONS: {
       cachedState.filterOptions = { ...cachedState.filterOptions, ...msg.options };
       saveState();
-
-      // Notify sender tab only
-      if (sender.tab?.id !== undefined) {
-        chrome.tabs.sendMessage(sender.tab.id, {
-          action: 'UPDATE_FILTER',
-          options: cachedState.filterOptions,
-        });
-      }
       sendResponse({ ok: true });
       return true;
     }
 
-    case 'ALREADY_DARK_DETECTED': {
+    case MSG.ALREADY_DARK_DETECTED: {
       const tabId = sender.tab?.id;
       if (tabId !== undefined && msg.detection) {
         tabDetections[tabId] = msg.detection;
@@ -201,31 +187,18 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return true;
     }
 
-    case 'GET_ALL_SITES': {
+    case MSG.GET_ALL_SITES: {
       sendResponse({ perSite: cachedState.perSite });
       return true;
     }
 
-    case 'RESET_ALL_SITES': {
+    case MSG.RESET_ALL_SITES: {
       cachedState.perSite = {};
       saveState();
-
-      // Notify all tabs to re-evaluate
-      chrome.tabs.query({}, (tabs) => {
-        for (const tab of tabs) {
-          if (tab.id === undefined) continue;
-          const domain = getDomainFromUrl(tab.url);
-          if (!domain) continue;
-          notifyTab(tab.id, domain);
-        }
-      });
+      notifyAllTabs();
       sendResponse({ ok: true });
       return true;
     }
-
-    case 'DARK_STATE_CHANGED':
-      sendResponse({ ok: true });
-      return true;
 
     default:
       return false;

--- a/apps/nightshift/src/content/dark-engine.ts
+++ b/apps/nightshift/src/content/dark-engine.ts
@@ -1,3 +1,4 @@
+import type { FilterOptions } from '../shared/types';
 import { hasOverride as checkOverride, getOverrideCSS } from './overrides';
 
 const STYLE_ID = 'nightshift-filter';
@@ -5,12 +6,6 @@ const OVERRIDE_STYLE_ID = 'nightshift-override';
 const COUNTER_INVERT_SELECTOR = 'img, video, canvas, svg, picture, object, embed';
 const COUNTER_INVERT_ATTR = 'data-nightshift-ci';
 const THROTTLE_MS = 100;
-
-interface FilterOptions {
-  brightness?: number;
-  contrast?: number;
-  sepia?: number;
-}
 
 interface EngineState {
   enabled: boolean;
@@ -44,24 +39,42 @@ function buildStyleContent(opts: FilterOptions): string {
   ].join('\n');
 }
 
-function counterInvertNew(): void {
-  const elements = document.querySelectorAll(COUNTER_INVERT_SELECTOR);
-  for (const el of elements) {
-    if (!el.hasAttribute(COUNTER_INVERT_ATTR)) {
-      el.setAttribute(COUNTER_INVERT_ATTR, '1');
+function markElement(el: Element): void {
+  if (!el.hasAttribute(COUNTER_INVERT_ATTR)) {
+    el.setAttribute(COUNTER_INVERT_ATTR, '1');
+  }
+}
+
+function counterInvertAdded(mutations: MutationRecord[]): void {
+  for (const mutation of mutations) {
+    for (const node of mutation.addedNodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue;
+      const el = node as Element;
+      if (el.matches(COUNTER_INVERT_SELECTOR)) {
+        markElement(el);
+      }
+      for (const child of el.querySelectorAll(COUNTER_INVERT_SELECTOR)) {
+        markElement(child);
+      }
     }
+  }
+}
+
+function counterInvertAll(): void {
+  for (const el of document.querySelectorAll(COUNTER_INVERT_SELECTOR)) {
+    markElement(el);
   }
 }
 
 function startObserver(): void {
   if (observer) return;
 
-  observer = new MutationObserver(() => {
+  observer = new MutationObserver((mutations) => {
     if (throttleTimeout) return;
     throttleTimeout = setTimeout(() => {
       throttleTimeout = null;
       requestAnimationFrame(() => {
-        counterInvertNew();
+        counterInvertAdded(mutations);
       });
     }, THROTTLE_MS);
   });
@@ -86,10 +99,8 @@ function stopObserver(): void {
 }
 
 export function applyDarkMode(opts?: FilterOptions): void {
-  if (state.enabled) return;
-
-  state.enabled = true;
   state.options = opts ?? {};
+  state.enabled = true;
 
   let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
   if (!style) {
@@ -99,11 +110,13 @@ export function applyDarkMode(opts?: FilterOptions): void {
   }
   style.textContent = buildStyleContent(state.options);
 
-  counterInvertNew();
+  counterInvertAll();
   startObserver();
 }
 
 export function removeDarkMode(): void {
+  if (!state.enabled) return;
+
   state.enabled = false;
   state.options = {};
 
@@ -201,17 +214,8 @@ export function detectNativeDarkMode(): DetectionResult {
   return { isDark: false, confidence: 'none', signals: [] };
 }
 
-export function isAlreadyDark(): boolean {
-  const result = detectNativeDarkMode();
-  return result.isDark && result.confidence === 'high';
-}
-
 export function hasOverride(domain: string): boolean {
   return checkOverride(domain);
-}
-
-export function loadOverride(domain: string): string | null {
-  return getOverrideCSS(domain);
 }
 
 export function applyOverride(domain: string): boolean {

--- a/apps/nightshift/src/content/index.ts
+++ b/apps/nightshift/src/content/index.ts
@@ -1,3 +1,4 @@
+import { MSG } from '../shared/messages';
 import {
   type DetectionResult,
   applyDarkMode,
@@ -24,7 +25,7 @@ import {
 
   // FOUC Phase 1: apply dark mode immediately at document_start
   // Check for site-specific CSS override first, then fall back to generic filter
-  chrome.runtime.sendMessage({ action: 'GET_STATE', domain: currentDomain }, (response) => {
+  chrome.runtime.sendMessage({ action: MSG.GET_STATE, domain: currentDomain }, (response) => {
     if (chrome.runtime.lastError) return;
     if (response?.effectiveEnabled) {
       if (hasOverride(currentDomain)) {
@@ -48,7 +49,7 @@ import {
 
     // Report detection to background (both high and low)
     chrome.runtime.sendMessage({
-      action: 'ALREADY_DARK_DETECTED',
+      action: MSG.ALREADY_DARK_DETECTED,
       detection,
     });
   };
@@ -86,22 +87,22 @@ import {
   // Message handler
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     switch (msg.action) {
-      case 'APPLY_DARK':
+      case MSG.APPLY_DARK:
         applyDarkMode(msg.options);
         sendResponse({ ok: true });
         return true;
-      case 'REMOVE_DARK':
+      case MSG.REMOVE_DARK:
         removeDarkMode();
         sendResponse({ ok: true });
         return true;
-      case 'UPDATE_FILTER':
+      case MSG.UPDATE_FILTER:
         updateFilter(msg.options);
         sendResponse({ ok: true });
         return true;
-      case 'GET_STATE':
+      case MSG.GET_STATE:
         sendResponse(getState());
         return true;
-      case 'IS_ALREADY_DARK':
+      case MSG.IS_ALREADY_DARK:
         sendResponse({ detection: detectNativeDarkMode() });
         return true;
       default:

--- a/apps/nightshift/src/popup/App.tsx
+++ b/apps/nightshift/src/popup/App.tsx
@@ -3,17 +3,13 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
+import { MSG } from '../shared/messages';
+import type { DarkDetection, FilterOptions, SiteMode } from '../shared/types';
+import { cycleSiteMode } from '../shared/types';
 import { CTABanner } from './cta-banner';
 import { SitesManager } from './sites-manager';
 
 type PopupView = 'main' | 'sites';
-type SiteMode = boolean | 'auto';
-
-interface DarkDetection {
-  isDark: boolean;
-  confidence: 'high' | 'low' | 'none';
-  signals: string[];
-}
 
 interface FilterValues {
   brightness: number;
@@ -42,6 +38,7 @@ export function App() {
 
   const tabIdRef = useRef<number | undefined>(undefined);
   const throttleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const filtersRef = useRef<FilterValues>(DEFAULT_FILTERS);
 
   useEffect(() => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -66,7 +63,7 @@ export function App() {
       setDomain(tabDomain);
 
       chrome.runtime.sendMessage(
-        { action: 'GET_STATE', domain: tabDomain, tabId: tab?.id },
+        { action: MSG.GET_STATE, domain: tabDomain, tabId: tab?.id },
         (response) => {
           if (chrome.runtime.lastError) {
             setLoading(false);
@@ -82,12 +79,14 @@ export function App() {
             setDarkDetection(response.darkDetection);
           }
 
-          const opts = response?.filterOptions ?? {};
-          setFilters({
+          const opts: FilterOptions = response?.filterOptions ?? {};
+          const loaded: FilterValues = {
             brightness: opts.brightness ?? 100,
             contrast: opts.contrast ?? 100,
             sepia: opts.sepia ?? 0,
-          });
+          };
+          setFilters(loaded);
+          filtersRef.current = loaded;
 
           setLoading(false);
         },
@@ -98,52 +97,46 @@ export function App() {
   const handleGlobalToggle = useCallback(() => {
     const newEnabled = !globalEnabled;
     setGlobalEnabled(newEnabled);
-    chrome.runtime.sendMessage({ action: 'SET_ENABLED', enabled: newEnabled });
+    chrome.runtime.sendMessage({ action: MSG.SET_ENABLED, enabled: newEnabled });
   }, [globalEnabled]);
 
   const handleSiteToggle = useCallback(() => {
     if (!domain) return;
-    let next: SiteMode;
-    if (siteMode === 'auto') {
-      next = true;
-    } else if (siteMode === true) {
-      next = false;
-    } else {
-      next = 'auto';
-    }
+    const next = cycleSiteMode(siteMode);
     setSiteMode(next);
-    chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: next });
+    chrome.runtime.sendMessage({ action: MSG.SET_SITE_ENABLED, domain, enabled: next });
   }, [domain, siteMode]);
 
   const handleApplyAnyway = useCallback(() => {
     if (!domain) return;
     setSiteMode(true);
-    chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: true });
+    chrome.runtime.sendMessage({ action: MSG.SET_SITE_ENABLED, domain, enabled: true });
   }, [domain]);
 
-  const sendFilterUpdate = useCallback(
-    (key: keyof FilterValues, value: number) => {
-      const newFilters = { ...filters, [key]: value };
-      setFilters(newFilters);
+  const sendFilterUpdate = useCallback((key: keyof FilterValues, value: number) => {
+    const newFilters = { ...filtersRef.current, [key]: value };
+    setFilters(newFilters);
+    filtersRef.current = newFilters;
 
-      // Throttled single-hop: popup → content script (no background relay)
-      if (throttleRef.current) return;
-      throttleRef.current = setTimeout(() => {
-        throttleRef.current = null;
-        if (tabIdRef.current !== undefined) {
-          chrome.tabs.sendMessage(tabIdRef.current, {
-            action: 'UPDATE_FILTER',
-            options: newFilters,
-          });
-        }
-      }, SLIDER_THROTTLE_MS);
-    },
-    [filters],
-  );
+    // Throttled single-hop: popup → content script (no background relay)
+    if (throttleRef.current) return;
+    throttleRef.current = setTimeout(() => {
+      throttleRef.current = null;
+      if (tabIdRef.current !== undefined) {
+        chrome.tabs.sendMessage(tabIdRef.current, {
+          action: MSG.UPDATE_FILTER,
+          options: filtersRef.current,
+        });
+      }
+    }, SLIDER_THROTTLE_MS);
+  }, []);
 
   const persistFilters = useCallback(() => {
-    chrome.runtime.sendMessage({ action: 'SET_FILTER_OPTIONS', options: filters });
-  }, [filters]);
+    chrome.runtime.sendMessage({
+      action: MSG.SET_FILTER_OPTIONS,
+      options: filtersRef.current,
+    });
+  }, []);
 
   const effectiveEnabled = siteMode !== 'auto' ? siteMode : globalEnabled;
   const siteLabel = siteMode === 'auto' ? 'Auto (global)' : siteMode ? 'Always ON' : 'Always OFF';

--- a/apps/nightshift/src/popup/sites-manager.tsx
+++ b/apps/nightshift/src/popup/sites-manager.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-
-type SiteMode = boolean | 'auto';
+import { MSG } from '../shared/messages';
+import type { SiteMode } from '../shared/types';
+import { cycleSiteMode } from '../shared/types';
 
 interface SiteEntry {
   domain: string;
@@ -19,7 +20,7 @@ export function SitesManager({ onBack }: SitesManagerProps) {
   const [loading, setLoading] = useState(true);
 
   const loadSites = useCallback(() => {
-    chrome.runtime.sendMessage({ action: 'GET_ALL_SITES' }, (response) => {
+    chrome.runtime.sendMessage({ action: MSG.GET_ALL_SITES }, (response) => {
       if (chrome.runtime.lastError) {
         setLoading(false);
         return;
@@ -51,16 +52,9 @@ export function SitesManager({ onBack }: SitesManagerProps) {
       const site = sites.find((s) => s.domain === domain);
       if (!site) return;
 
-      let next: SiteMode;
-      if (site.enabled === 'auto') {
-        next = true;
-      } else if (site.enabled === true) {
-        next = false;
-      } else {
-        next = 'auto';
-      }
+      const next = cycleSiteMode(site.enabled);
 
-      chrome.runtime.sendMessage({ action: 'SET_SITE_ENABLED', domain, enabled: next });
+      chrome.runtime.sendMessage({ action: MSG.SET_SITE_ENABLED, domain, enabled: next });
 
       setSites((prev) =>
         prev
@@ -72,7 +66,7 @@ export function SitesManager({ onBack }: SitesManagerProps) {
   );
 
   const handleResetAll = useCallback(() => {
-    chrome.runtime.sendMessage({ action: 'RESET_ALL_SITES' }, () => {
+    chrome.runtime.sendMessage({ action: MSG.RESET_ALL_SITES }, () => {
       if (chrome.runtime.lastError) return;
       setSites([]);
     });

--- a/apps/nightshift/src/shared/messages.ts
+++ b/apps/nightshift/src/shared/messages.ts
@@ -1,0 +1,16 @@
+/** Message action constants for chrome.runtime message passing */
+export const MSG = {
+  GET_STATE: 'GET_STATE',
+  SET_ENABLED: 'SET_ENABLED',
+  SET_SITE_ENABLED: 'SET_SITE_ENABLED',
+  SET_FILTER_OPTIONS: 'SET_FILTER_OPTIONS',
+  UPDATE_FILTER: 'UPDATE_FILTER',
+  APPLY_DARK: 'APPLY_DARK',
+  REMOVE_DARK: 'REMOVE_DARK',
+  ALREADY_DARK_DETECTED: 'ALREADY_DARK_DETECTED',
+  GET_ALL_SITES: 'GET_ALL_SITES',
+  RESET_ALL_SITES: 'RESET_ALL_SITES',
+  IS_ALREADY_DARK: 'IS_ALREADY_DARK',
+} as const;
+
+export type MessageAction = (typeof MSG)[keyof typeof MSG];

--- a/apps/nightshift/src/shared/types.ts
+++ b/apps/nightshift/src/shared/types.ts
@@ -1,0 +1,22 @@
+/** Shared types and constants for NightShift extension */
+
+export type SiteMode = boolean | 'auto';
+
+export interface FilterOptions {
+  brightness?: number;
+  contrast?: number;
+  sepia?: number;
+}
+
+export interface DarkDetection {
+  isDark: boolean;
+  confidence: 'high' | 'low' | 'none';
+  signals: string[];
+}
+
+/** Cycle site mode: auto → true → false → auto */
+export function cycleSiteMode(current: SiteMode): SiteMode {
+  if (current === 'auto') return true;
+  if (current === true) return false;
+  return 'auto';
+}


### PR DESCRIPTION
## Summary

Code quality, reuse, and efficiency improvements for NightShift Dark Mode extension based on 3-agent review (`/simplify`).

### Bug Fixes
- **Fix stale closure in slider throttle** — `sendFilterUpdate` now reads from `filtersRef.current` instead of closed-over `filters` state. Fast slider dragging no longer sends stale values to content script.
- **Fix `applyDarkMode` ignoring updated options** — removed early return when already enabled, so cross-tab sync and re-apply with new filter options works correctly.
- **Add idempotency guard to `removeDarkMode`** — prevents unnecessary DOM cleanup when already disabled.

### Code Reuse
- **Shared types** (`src/shared/types.ts`) — `DarkDetection`, `FilterOptions`, `SiteMode` extracted from 3 duplicate definitions across popup, background, and content.
- **Shared message constants** (`src/shared/messages.ts`) — `MSG` object replaces 12 stringly-typed action literals across 4 files.
- **Shared `cycleSiteMode()`** — deduplicates `auto→true→false→auto` logic from App.tsx and sites-manager.tsx.

### Efficiency
- **MutationObserver optimization** — `counterInvertAdded()` processes only `mutation.addedNodes` instead of full `document.querySelectorAll()` on every mutation. O(k) vs O(n) where k = new elements.
- **Extract `notifyAllTabs()` helper** — deduplicates identical loops in `SET_ENABLED` and `RESET_ALL_SITES`.
- **Remove `SET_FILTER_OPTIONS` echo** — popup already updates content script via single-hop; background echo was redundant.
- **Fix `GET_STATE` data leak** — returns only needed fields instead of spreading entire `cachedState` (which leaked `perSite`).

### Dead Code Removal
- `DARK_STATE_CHANGED` handler (no-op)
- `isAlreadyDark()` and `loadOverride()` exports (unused)

## Test plan
- [ ] Toggle global dark mode ON/OFF — verify works across tabs
- [ ] Drag brightness/contrast/sepia sliders quickly — verify no stale values
- [ ] Test per-site toggle cycling (Auto → ON → OFF → Auto)
- [ ] Test site manager search and reset
- [ ] Verify cross-tab sync via storage.onChanged
- [ ] Test CSS overrides on GitHub, Reddit, HN
- [ ] Verify build output sizes are similar (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)