### PR TITLE
test(full-page-screenshot): add E2E picker tests

### DIFF
--- a/apps/full-page-screenshot/.gitignore
+++ b/apps/full-page-screenshot/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/apps/full-page-screenshot/e2e/fixtures.ts
+++ b/apps/full-page-screenshot/e2e/fixtures.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { type BrowserContext, test as base, chromium } from '@playwright/test';
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture pattern
+  context: async ({}, use) => {
+    const pathToExtension = path.resolve(__dirname, '..', 'dist');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+export const expect = test.expect;
+
+export async function openPopup(context: BrowserContext, extensionId: string) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.getByRole('button', { name: 'Capture Full Page' }).waitFor({ timeout: 5000 });
+  return page;
+}

--- a/apps/full-page-screenshot/e2e/picker.test.ts
+++ b/apps/full-page-screenshot/e2e/picker.test.ts
@@ -1,0 +1,156 @@
+import { expect, openPopup, test } from './fixtures';
+
+async function getH1Box(page: import('@playwright/test').Page) {
+  const box = await page.locator('h1').boundingBox();
+  if (!box) throw new Error('h1 bounding box not found');
+  return box;
+}
+
+function center(box: { x: number; y: number; width: number; height: number }) {
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+test.describe('Element Picker', () => {
+  test('clicking Select Element injects picker overlay on target page', async ({
+    context,
+    extensionId,
+  }) => {
+    const examplePage = await context.newPage();
+    await examplePage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    const popup = await openPopup(context, extensionId);
+
+    // Make example.com the active tab so background's getActiveTabId() returns it
+    await examplePage.bringToFront();
+
+    // Trigger picker from popup context
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+
+    // Switch to example page and verify overlay elements
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+    await expect(examplePage.locator('#__fps-overlay')).toBeAttached();
+
+    await popup.close();
+  });
+
+  test('hovering over element shows green highlight box', async ({ context, extensionId }) => {
+    const examplePage = await context.newPage();
+    await examplePage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    // Get h1 bounding box before picker activation (glass blocks element queries)
+    const h1Box = await getH1Box(examplePage);
+
+    const popup = await openPopup(context, extensionId);
+    await examplePage.bringToFront();
+
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+
+    // Wait past ARM_DELAY_MS (400ms)
+    await examplePage.waitForTimeout(500);
+
+    // Move mouse over h1 location
+    const { x, y } = center(h1Box);
+    await examplePage.mouse.move(x, y);
+
+    // Assert highlight becomes visible with green border
+    const highlight = examplePage.locator('#__fps-highlight');
+    await expect(highlight).toBeVisible({ timeout: 5000 });
+
+    const borderColor = await highlight.evaluate((el) => getComputedStyle(el).borderColor);
+    expect(borderColor).toBe('rgb(34, 197, 94)');
+
+    await popup.close();
+  });
+
+  test('tooltip shows element info', async ({ context, extensionId }) => {
+    const examplePage = await context.newPage();
+    await examplePage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    const h1Box = await getH1Box(examplePage);
+
+    const popup = await openPopup(context, extensionId);
+    await examplePage.bringToFront();
+
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+
+    await examplePage.waitForTimeout(500);
+
+    const { x, y } = center(h1Box);
+    await examplePage.mouse.move(x, y);
+
+    const tooltip = examplePage.locator('#__fps-tooltip');
+    await expect(tooltip).toBeVisible({ timeout: 5000 });
+
+    const tooltipText = await tooltip.textContent();
+    expect(tooltipText?.toLowerCase()).toContain('h1');
+
+    await popup.close();
+  });
+
+  test('clicking element removes overlay', async ({ context, extensionId }) => {
+    const examplePage = await context.newPage();
+    await examplePage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    const h1Box = await getH1Box(examplePage);
+
+    const popup = await openPopup(context, extensionId);
+    await examplePage.bringToFront();
+
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+
+    await examplePage.waitForTimeout(500);
+
+    // Hover then click at h1 location
+    const { x, y } = center(h1Box);
+    await examplePage.mouse.move(x, y);
+    await examplePage.waitForTimeout(200);
+    await examplePage.mouse.click(x, y);
+
+    // Wait for glass overlay to be removed from DOM
+    await examplePage.waitForSelector('#__fps-glass', { state: 'detached', timeout: 10_000 });
+    await expect(examplePage.locator('#__fps-overlay')).not.toBeAttached();
+
+    await popup.close();
+  });
+
+  test('picker can be re-activated after selection', async ({ context, extensionId }) => {
+    const examplePage = await context.newPage();
+    await examplePage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    const h1Box = await getH1Box(examplePage);
+
+    const popup = await openPopup(context, extensionId);
+    await examplePage.bringToFront();
+
+    // First activation
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+
+    await examplePage.waitForTimeout(500);
+
+    // Select an element to complete the first picker session
+    const { x, y } = center(h1Box);
+    await examplePage.mouse.move(x, y);
+    await examplePage.waitForTimeout(200);
+    await examplePage.mouse.click(x, y);
+
+    // Wait for overlay cleanup
+    await examplePage.waitForSelector('#__fps-glass', { state: 'detached', timeout: 10_000 });
+
+    // Wait for potential capture to process
+    await examplePage.waitForTimeout(1000);
+
+    // Re-activate picker
+    await examplePage.bringToFront();
+    await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_PICKER' }));
+
+    // Verify glass overlay appears again
+    await examplePage.waitForSelector('#__fps-glass', { timeout: 10_000 });
+    await expect(examplePage.locator('#__fps-overlay')).toBeAttached();
+
+    await popup.close();
+  });
+});

--- a/apps/full-page-screenshot/package.json
+++ b/apps/full-page-screenshot/package.json
@@ -13,6 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
     "package": "node ../../scripts/package-extension.mjs"
   },
   "dependencies": {
@@ -30,6 +33,7 @@
     "@types/chrome": "^0.0.300",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@playwright/test": "^1.58.2",
     "@vitejs/plugin-react": "^4.0.0",
     "concurrently": "^9.0.0",
     "shadcn": "^3.8.5",

--- a/apps/full-page-screenshot/playwright.config.ts
+++ b/apps/full-page-screenshot/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: { trace: 'on-first-retry' },
+});

--- a/apps/full-page-screenshot/tsconfig.json
+++ b/apps/full-page-screenshot/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "e2e", "playwright.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@rayshar/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for the element picker feature in Full Page Screenshot
- 5 tests covering: overlay injection, hover highlighting (green border), tooltip display, click-to-select cleanup, and picker re-activation
- Add `@playwright/test` devDependency, e2e scripts, Playwright config, and fixtures

## Test plan
- [x] `pnpm test` passes (unit tests, no regressions)
- [x] `pnpm lint` passes (Biome, no violations)
- [x] `pnpm type-check` passes
- [x] `npx playwright test` — all 5 E2E tests pass (25s)
- [x] Pre-commit hooks pass (test + lint + type-check + commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)