### PR TITLE
test(full-page-screenshot): add E2E popup UI tests with Playwright

### DIFF
--- a/apps/full-page-screenshot/.gitignore
+++ b/apps/full-page-screenshot/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/apps/full-page-screenshot/e2e/fixtures.ts
+++ b/apps/full-page-screenshot/e2e/fixtures.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { type BrowserContext, test as base, chromium } from '@playwright/test';
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture pattern
+  context: async ({}, use) => {
+    const pathToExtension = path.resolve(__dirname, '..', 'dist');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+export const expect = test.expect;
+
+export async function openPopup(context: BrowserContext, extensionId: string) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.getByRole('button', { name: 'Capture Full Page' }).waitFor({ timeout: 5000 });
+  return page;
+}

--- a/apps/full-page-screenshot/e2e/popup.test.ts
+++ b/apps/full-page-screenshot/e2e/popup.test.ts
@@ -1,0 +1,130 @@
+import type { Page } from '@playwright/test';
+import { expect, openPopup, test } from './fixtures';
+
+/**
+ * Simulate an incoming chrome.runtime.onMessage event in the popup.
+ *
+ * `chrome.runtime.sendMessage()` from the popup goes to the background, not
+ * back to the popup's own onMessage listener.  To trigger the popup's listener
+ * we need to dispatch the event directly via the internal Chrome event API.
+ */
+async function simulateMessage(page: Page, msg: Record<string, unknown>) {
+  await page.evaluate((m) => {
+    // Chrome extension Event objects expose `dispatch` or we can call
+    // registered listeners via the public `_listeners` array. The simplest
+    // reliable approach: use the undocumented but stable `dispatch` method
+    // available on chrome.runtime.onMessage in MV3 popup contexts.  If that
+    // doesn't exist, fall back to iterating registered listeners.
+    const event = chrome.runtime.onMessage as unknown as {
+      _listeners?: Array<(msg: unknown) => void>;
+      dispatch: (msg: unknown, sender: unknown, sendResponse: () => void) => void;
+    };
+
+    if (typeof event.dispatch === 'function') {
+      event.dispatch(m, {}, () => {});
+    } else if (Array.isArray(event._listeners)) {
+      for (const fn of event._listeners) {
+        fn(m);
+      }
+    }
+  }, msg);
+}
+
+test.describe('Popup -- idle state', () => {
+  test('both buttons visible and enabled in idle state', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    const captureBtn = page.getByRole('button', { name: 'Capture Full Page' });
+    const selectBtn = page.getByRole('button', { name: 'Select Element' });
+
+    await expect(captureBtn).toBeVisible();
+    await expect(captureBtn).toBeEnabled();
+    await expect(selectBtn).toBeVisible();
+    await expect(selectBtn).toBeEnabled();
+  });
+
+  test('correct button labels in idle', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    await expect(page.getByRole('button', { name: 'Capture Full Page' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Select Element' })).toBeVisible();
+    await expect(page.getByText('Capturing...')).toBeHidden();
+    await expect(page.getByText('Selecting...')).toBeHidden();
+  });
+
+  test('feedback link present', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    const link = page.getByRole('link', { name: /Send feedback/ });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', /docs\.google\.com\/forms/);
+  });
+});
+
+test.describe('Popup -- state transitions via messages', () => {
+  test('CAPTURE_PREPARING disables buttons and shows Capturing...', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    await simulateMessage(page, { action: 'CAPTURE_PREPARING' });
+
+    const captureBtn = page.getByRole('button', { name: 'Capturing...' });
+    await expect(captureBtn).toBeVisible();
+    await expect(captureBtn).toBeDisabled();
+
+    const selectBtn = page.getByRole('button', { name: 'Select Element' });
+    await expect(selectBtn).toBeDisabled();
+  });
+
+  test('PROGRESS shows progress bar and capture count', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    await simulateMessage(page, { action: 'PROGRESS', current: 2, total: 5 });
+
+    await expect(page.getByText('Capturing... 2/5')).toBeVisible();
+    await expect(page.getByRole('progressbar')).toBeVisible();
+  });
+
+  test('CAPTURE_COMPLETE shows done message', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    await simulateMessage(page, { action: 'CAPTURE_COMPLETE' });
+
+    await expect(page.getByText('Done! Screenshot saved.')).toBeVisible();
+  });
+
+  test('done state auto-resets after 2s', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    await simulateMessage(page, { action: 'CAPTURE_COMPLETE' });
+
+    await expect(page.getByText('Done! Screenshot saved.')).toBeVisible();
+
+    // Wait for auto-reset (~2s timeout in App.tsx)
+    await page.waitForTimeout(2500);
+
+    await expect(page.getByText('Done! Screenshot saved.')).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Capture Full Page' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Select Element' })).toBeEnabled();
+  });
+
+  test('CAPTURE_ERROR shows error text and auto-resets', async ({ context, extensionId }) => {
+    const page = await openPopup(context, extensionId);
+
+    await simulateMessage(page, { action: 'CAPTURE_ERROR' });
+
+    await expect(
+      page.getByText('Capture failed. Try using "Select Element" instead.'),
+    ).toBeVisible();
+
+    // Wait for auto-reset (~4s timeout in App.tsx)
+    await page.waitForTimeout(4500);
+
+    await expect(
+      page.getByText('Capture failed. Try using "Select Element" instead.'),
+    ).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Capture Full Page' })).toBeEnabled();
+  });
+});

--- a/apps/full-page-screenshot/package.json
+++ b/apps/full-page-screenshot/package.json
@@ -13,7 +13,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "node ../../scripts/package-extension.mjs"
+    "package": "node ../../scripts/package-extension.mjs",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
@@ -36,6 +39,7 @@
     "tailwindcss": "^4.0.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "@playwright/test": "^1.50.0"
   }
 }

--- a/apps/full-page-screenshot/playwright.config.ts
+++ b/apps/full-page-screenshot/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    trace: 'on-first-retry',
+  },
+});

--- a/apps/full-page-screenshot/tsconfig.json
+++ b/apps/full-page-screenshot/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "e2e", "playwright.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.58.2
       '@rayshar/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
## Summary
- Add Playwright E2E test infrastructure for Full Page Screenshot extension (config, fixtures, .gitignore)
- Add 8 popup UI tests: 3 idle-state tests (buttons, labels, feedback link) and 5 state-transition tests via simulated `chrome.runtime.onMessage` events (preparing, progress, complete with auto-reset, error with auto-reset)
- Add `@playwright/test` devDependency and `test:e2e` / `test:e2e:ui` / `test:e2e:headed` scripts
- Exclude `e2e/` and `playwright.config.ts` from TypeScript compilation

## Test plan
- [x] Existing unit tests pass (`pnpm test`)
- [x] All 8 E2E tests pass (`npx playwright test` — 8 passed in ~16s)
- [x] Pre-commit hooks pass (type-check + lint + test + commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)