### PR TITLE
feat(full-page-screenshot): add E2E content script integration tests

### DIFF
--- a/apps/full-page-screenshot/.gitignore
+++ b/apps/full-page-screenshot/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/apps/full-page-screenshot/e2e/content-script.test.ts
+++ b/apps/full-page-screenshot/e2e/content-script.test.ts
@@ -1,0 +1,164 @@
+import { expect, openPopup, test, triggerCaptureAndWait } from './fixtures';
+
+test.describe('Content Script Integration', () => {
+  test('scrollbar-hide style injected during capture and removed after', async ({
+    context,
+    extensionId,
+  }) => {
+    const targetPage = await context.newPage();
+    await targetPage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    // Set up MutationObserver to detect scrollbar-hide style injection
+    await targetPage.evaluate(() => {
+      (window as Record<string, unknown>).__scrollbarHideDetected = false;
+      const observer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          for (const node of m.addedNodes) {
+            if ((node as Element).id === '__fps-scrollbar-hide') {
+              (window as Record<string, unknown>).__scrollbarHideDetected = true;
+            }
+          }
+        }
+      });
+      observer.observe(document.head, { childList: true });
+    });
+
+    const popup = await openPopup(context, extensionId);
+    await triggerCaptureAndWait(popup, targetPage);
+
+    // Style WAS injected during capture
+    const detected = await targetPage.evaluate(
+      () => (window as Record<string, unknown>).__scrollbarHideDetected,
+    );
+    expect(detected).toBe(true);
+
+    // Style was removed after RESTORE
+    const styleExists = await targetPage.evaluate(
+      () => document.getElementById('__fps-scrollbar-hide') !== null,
+    );
+    expect(styleExists).toBe(false);
+  });
+
+  test('page scroll position restored after capture', async ({ context, extensionId }) => {
+    const targetPage = await context.newPage();
+    await targetPage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    // Make page tall enough to scroll
+    await targetPage.evaluate(() => {
+      document.body.style.height = '3000px';
+    });
+
+    // Scroll to Y=200
+    await targetPage.evaluate(() => window.scrollTo(0, 200));
+    expect(await targetPage.evaluate(() => window.scrollY)).toBe(200);
+
+    const popup = await openPopup(context, extensionId);
+    await triggerCaptureAndWait(popup, targetPage);
+
+    // Scroll position should be restored
+    await targetPage.bringToFront();
+    const scrollY = await targetPage.evaluate(() => window.scrollY);
+    expect(scrollY).toBe(200);
+  });
+
+  test('fixed/sticky elements hidden during multi-frame capture and restored', async ({
+    context,
+    extensionId,
+  }) => {
+    const targetPage = await context.newPage();
+    await targetPage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    // Make page tall for multi-frame capture
+    await targetPage.evaluate(() => {
+      document.body.style.height = '5000px';
+    });
+
+    // Inject a fixed header element
+    await targetPage.evaluate(() => {
+      const header = document.createElement('div');
+      header.id = 'test-fixed-header';
+      header.style.position = 'fixed';
+      header.style.top = '0';
+      header.style.width = '100%';
+      header.style.height = '50px';
+      header.style.background = 'red';
+      header.style.zIndex = '1000';
+      document.body.appendChild(header);
+    });
+
+    // Set up observer to detect when fixed header visibility changes
+    await targetPage.evaluate(() => {
+      (window as Record<string, unknown>).__headerWasHidden = false;
+      const observer = new MutationObserver(() => {
+        const header = document.getElementById('test-fixed-header');
+        if (header && header.style.visibility === 'hidden') {
+          (window as Record<string, unknown>).__headerWasHidden = true;
+        }
+      });
+      const header = document.getElementById('test-fixed-header');
+      if (header) {
+        observer.observe(header, { attributes: true, attributeFilter: ['style'] });
+      }
+    });
+
+    const popup = await openPopup(context, extensionId);
+    await triggerCaptureAndWait(popup, targetPage);
+
+    // HIDE_FIXED was called (header was hidden during capture)
+    const wasHidden = await targetPage.evaluate(
+      () => (window as Record<string, unknown>).__headerWasHidden,
+    );
+    expect(wasHidden).toBe(true);
+
+    // Header visibility is restored after RESTORE
+    const visibility = await targetPage.evaluate(() => {
+      const h = document.getElementById('test-fixed-header');
+      return h ? h.style.visibility : 'not found';
+    });
+    expect(visibility).not.toBe('hidden');
+  });
+
+  test('second capture works after first (injection guard properly managed)', async ({
+    context,
+    extensionId,
+  }) => {
+    const targetPage = await context.newPage();
+    await targetPage.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+
+    // Set up observer to count scrollbar-hide style injections across both captures.
+    // Each capture injects the style during PREPARE and removes it during RESTORE.
+    await targetPage.evaluate(() => {
+      (window as Record<string, unknown>).__scrollbarHideCount = 0;
+      const observer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          for (const node of m.addedNodes) {
+            if ((node as Element).id === '__fps-scrollbar-hide') {
+              (window as Record<string, unknown>).__scrollbarHideCount =
+                ((window as Record<string, unknown>).__scrollbarHideCount as number) + 1;
+            }
+          }
+        }
+      });
+      observer.observe(document.head, { childList: true });
+    });
+
+    // First capture
+    const popup = await openPopup(context, extensionId);
+    await triggerCaptureAndWait(popup, targetPage);
+
+    // Wait for the "Capture Full Page" button to become enabled after auto-reset
+    await expect(popup.getByRole('button', { name: 'Capture Full Page' })).toBeEnabled({
+      timeout: 5000,
+    });
+
+    // Second capture
+    await triggerCaptureAndWait(popup, targetPage);
+
+    // Both captures injected the scrollbar-hide style, proving re-injection worked.
+    // Count may exceed 2 when allFrames injection adds the style in sub-frames.
+    const count = await targetPage.evaluate(
+      () => (window as Record<string, unknown>).__scrollbarHideCount as number,
+    );
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/full-page-screenshot/e2e/fixtures.ts
+++ b/apps/full-page-screenshot/e2e/fixtures.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import { type BrowserContext, type Page, test as base, chromium } from '@playwright/test';
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture pattern
+  context: async ({}, use) => {
+    const pathToExtension = path.resolve(__dirname, '..', 'dist');
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  extensionId: async ({ context }, use) => {
+    let [background] = context.serviceWorkers();
+    if (!background) {
+      background = await context.waitForEvent('serviceworker');
+    }
+    const extensionId = background.url().split('/')[2];
+    await use(extensionId);
+  },
+});
+
+export const expect = test.expect;
+
+export async function openPopup(context: BrowserContext, extensionId: string) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/popup.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.getByRole('button', { name: 'Capture Full Page' }).waitFor({ timeout: 5000 });
+  return page;
+}
+
+/**
+ * Wait for capture to finish. RESTORE runs before downloadCanvas, so content
+ * script state is fully restored even when the download step fails (e.g.
+ * URL.createObjectURL unavailable in service worker). We accept either the
+ * success message or the error message as proof that the capture loop completed.
+ */
+export async function waitForCaptureFinish(popup: Page, timeout = 30_000) {
+  const done = popup.getByText('Done! Screenshot saved.');
+  const error = popup.getByText('Capture failed', { exact: false });
+  await expect(done.or(error)).toBeVisible({ timeout });
+}
+
+/**
+ * Trigger a full-page capture on `targetPage` via the popup and wait for it to
+ * finish. Handles the bringToFront dance required so the background service
+ * worker's `getActiveTabId()` resolves to the target page.
+ */
+export async function triggerCaptureAndWait(popup: Page, targetPage: Page) {
+  await targetPage.bringToFront();
+  await popup.evaluate(() => chrome.runtime.sendMessage({ action: 'START_CAPTURE' }));
+  await popup.bringToFront();
+  await waitForCaptureFinish(popup);
+}

--- a/apps/full-page-screenshot/package.json
+++ b/apps/full-page-screenshot/package.json
@@ -13,7 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "node ../../scripts/package-extension.mjs"
+    "package": "node ../../scripts/package-extension.mjs",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",
@@ -25,6 +27,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@rayshar/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4.0.0",
     "@types/chrome": "^0.0.300",

--- a/apps/full-page-screenshot/playwright.config.ts
+++ b/apps/full-page-screenshot/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: { trace: 'on-first-retry' },
+});

--- a/apps/full-page-screenshot/tsconfig.json
+++ b/apps/full-page-screenshot/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "e2e", "playwright.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.58.2
       '@rayshar/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for Full Page Screenshot content script integration
- Tests cover scrollbar-hide style injection/removal, scroll position restoration, fixed/sticky element hiding during multi-frame capture, and injection guard reset for consecutive captures
- Add `triggerCaptureAndWait` and `waitForCaptureFinish` helpers to fixtures for DRY test orchestration

## Test plan
- [x] All 4 E2E tests pass locally (`npx playwright test` — 4 passed in ~27s)
- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type-check passes (`pnpm type-check`)
- [x] Pre-commit hooks pass (lefthook: test + lint + type-check + commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)